### PR TITLE
Upgrade Chartist to 0.10.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "ember-qunit-notifications": "0.1.0"
   },
   "devDependencies": {
-    "chartist": "~0.9.1"
+    "chartist": "~0.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-chartist",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Ember Addon for Chartist.js",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Chartist 0.9.1 has a few bugs, including problems with single-value graphs (see: https://github.com/gionkunz/chartist-js/issues/716). 0.9.9 fixes the issue, but I'm just bumping it to the latest version.