### PR TITLE
fix(doc): remove line # from README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This is an ember-cli wrapper for [Chartist](https://github.com/gionkunz/chartist-js).
 It allows you to render Chartist charts in your templates using components.
 
-[Chartist version in use](https://github.com/jherdman/ember-cli-chartist/blob/master/blueprints/ember-cli-chartist/index.js#L6).
+You can see which version of Chartist is used [by examining `blueprints/ember-cli-chartist/index.js`](https://github.com/jherdman/ember-cli-chartist/blob/master/blueprints/ember-cli-chartist/index.js).
 
 ## Setup
 


### PR DESCRIPTION
The `README.md` link to the file that defines which version of Charist will be used was not pointing to the most relevant line number in that file. Since this documentation is not automatically generated it is likely that as lines are added or removed from this file this line number will change again. Therefore it has been removed. The file is sufficiently short that this shouldn't cause any trouble.

Closes #68