### PR TITLE
Remove bower dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,11 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower phantomjs-prebuilt
-  - bower --version
+  - npm install -g phantomjs-prebuilt
   - phantomjs --version
 
 install:
   - npm install
-  - bower install
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/blueprints/ember-cli-chartist/index.js
+++ b/blueprints/ember-cli-chartist/index.js
@@ -9,6 +9,6 @@ module.exports = {
   },
 
   beforeInstall: function(options) {
-    return this.addBowerPackageToProject('chartist', '~0.9.8');
+    return this.addPackageToProject('chartist', '^0.10.1');
   }
 };

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
 
 var path = require('path');
 var Funnel = require('broccoli-funnel');
-var MergeTrees = require('broccoli-merge-trees');
+var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
+
   name: 'ember-cli-chartist',
 
   treeForVendor(vendorTree) {
@@ -18,51 +19,23 @@ module.exports = {
       ],
     });
 
-    var chartistTreeSCSS = new Funnel(chartistPath, {
-      srcDir: 'scss',
-
-      include: [
-        '*.scss',
-      ],
-    });
-
-    return new MergeTrees([
+    return mergeTrees([
       vendorTree,
       chartistTree,
-      chartistTreeSCSS,
     ]);
+  },
+
+  treeForStyles() {
+    var chartistPath = path.dirname(require.resolve('chartist'));
+
+    return new Funnel(chartistPath, {
+      srcDir: 'scss',
+    });
   },
 
   included(app) {
     this._super.included.apply(this, arguments);
-
     app.import('vendor/chartist.js');
-    app.import('vendor/chartist.css');
-    app.import('vendor/chartist.scss');
   },
 
-  //included: function included(app, parentAddon) {
-  //  var target = (parentAddon || app);
-
-  //  var options = target.options['ember-cli-chartist'] || {};
-  //  var chartistPath = path.join(target.bowerDirectory, 'chartist', 'dist');
-
-  //  if (options.useCustomCSS) {
-  //    target.options.sassOptions = target.options.sassOptions || {};
-  //    target.options.sassOptions.includePaths = target.options.sassOptions.includePaths || [];
-
-  //    target.options.sassOptions.includePaths.push(
-  //      path.join(chartistPath, 'scss')
-  //    );
-
-  //    target.options.sassOptions.includePaths.push(
-  //      path.join(chartistPath, 'scss', 'settings')
-  //    );
-
-  //  } else {
-  //    target.import(path.join(chartistPath, 'chartist.min.css'));
-  //  }
-
-  //  app.import(path.join(chartistPath, 'chartist.js'));
-  //}
 };

--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ module.exports = {
       ],
     });
 
-    return mergeTrees([
-      vendorTree,
-      chartistTree,
-    ]);
+    return vendorTree ?
+      mergeTrees([
+        vendorTree,
+        chartistTree,
+      ]) :
+      chartistTree;
   },
 
   treeForStyles() {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const path = require('path');
+const chalk = require('chalk');
 const Funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 
@@ -37,9 +38,15 @@ module.exports = {
 
   treeForStyles() {
     if (this.appOptions.useCustomCSS) {
+      this.ui.writeLine(chalk.yellow(
+        "[ember-cli-chartist] DEPRECATION: In the next major release (v2.0.0) of " +
+        "ember-cli-chartist, the import paths for chartist.scss and chartist-settings.scss will" +
+        " be changing. They will become 'chartist/chartist.scss' and " +
+        "'chartist/settings/chartist-settings.scss', respectively.\n"
+      ));
       return new Funnel(this.chartistPath, {
         srcDir: 'scss',
-        destDir: 'chartist',
+        // destDir: 'chartist',
       });
     }
   },

--- a/index.js
+++ b/index.js
@@ -1,18 +1,28 @@
 /* jshint node: true */
 'use strict';
 
-var path = require('path');
-var Funnel = require('broccoli-funnel');
-var mergeTrees = require('broccoli-merge-trees');
+const path = require('path');
+const Funnel = require('broccoli-funnel');
+const mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
 
   name: 'ember-cli-chartist',
 
-  treeForVendor(vendorTree) {
-    var chartistPath = path.dirname(require.resolve('chartist'));
+  included(app) {
+    this._super.included.apply(this, arguments);
 
-    var chartistTree = new Funnel(chartistPath, {
+    this.chartistPath = path.dirname(require.resolve('chartist'));
+    this.appOptions = app.options['ember-cli-chartist'] || {};
+
+    app.import('vendor/chartist.js');
+    if (!this.appOptions.useCustomCSS) {
+      app.import('vendor/chartist.css');
+    }
+  },
+
+  treeForVendor(vendorTree) {
+    const chartistTree = new Funnel(this.chartistPath, {
       files: [
         'chartist.js',
         'chartist.css',
@@ -26,17 +36,14 @@ module.exports = {
   },
 
   treeForStyles() {
-    var chartistPath = path.dirname(require.resolve('chartist'));
-
-    return new Funnel(chartistPath, {
-      srcDir: 'scss',
-      destDir: 'chartist',
-    });
+    if (this.appOptions.useCustomCSS) {
+      return new Funnel(this.chartistPath, {
+        srcDir: 'scss',
+        destDir: 'chartist',
+      });
+    }
   },
 
-  included(app) {
-    this._super.included.apply(this, arguments);
-    app.import('vendor/chartist.js');
-  },
+
 
 };

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
 
     return new Funnel(chartistPath, {
       srcDir: 'scss',
+      destDir: 'chartist',
     });
   },
 

--- a/index.js
+++ b/index.js
@@ -30,15 +30,10 @@ module.exports = {
       ],
     });
 
-    return vendorTree ?
-      mergeTrees([
-        vendorTree,
-        chartistTree,
-      ]) :
-      chartistTree;
+    return vendorTree ? mergeTrees([vendorTree, chartistTree]) : chartistTree;
   },
 
-  treeForStyles() {
+  treeForStyles(stylesTree) {
     if (this.appOptions.useCustomCSS) {
       this.ui.writeLine(chalk.yellow(
         "[ember-cli-chartist] DEPRECATION: In the next major release (v2.0.0) of " +
@@ -46,10 +41,13 @@ module.exports = {
         " be changing. They will become 'chartist/chartist.scss' and " +
         "'chartist/settings/chartist-settings.scss', respectively.\n"
       ));
-      return new Funnel(this.chartistPath, {
+
+      const chartistTree = new Funnel(this.chartistPath, {
         srcDir: 'scss',
         // destDir: 'chartist',
       });
+
+      return stylesTree ? mergeTrees([stylesTree, chartistTree]) : chartistTree;
     }
   },
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -8,7 +8,7 @@ $ct-series-colors: (
   #FF9800
 );
 
-@import "chartist";
+@import "chartist/chartist";
 
 .container {
   font-family: helvetica, arial, sans-serif;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -8,7 +8,7 @@ $ct-series-colors: (
   #FF9800
 );
 
-@import "chartist/chartist";
+@import "chartist";
 
 .container {
   font-family: helvetica, arial, sans-serif;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -8,7 +8,7 @@ $ct-series-colors: (
   #FF9800
 );
 
-@import "chartist.css";
+@import "chartist";
 
 .container {
   font-family: helvetica, arial, sans-serif;


### PR DESCRIPTION
I think I've got this working. Let me know if you find anything I missed. The main change is using `treeForStyles()` to handle the SCSS so it ends up in the Sass preprocessor's search path (`/app/styles`).

I do want to raise a small discussion on whether we want to deposit the Chartist files directly into the root of the styles directory, or in an `/app/styles/chartist` subdirectory. The latter seems to be what most addons that handle Sass do, presumably to minimize chances of file conflicts, and that's a major point in favor of that approach. The negative is that importing the Chartist Sass into `app.scss` becomes
```scss
@import "chartist/chartist";
@import "chartist/settings/chartist-settings";
```

which could be seen as somewhat redundantly verbose.